### PR TITLE
feat: automatically inject plenary.nvim runtimepath

### DIFF
--- a/run_tests.lua
+++ b/run_tests.lua
@@ -1,3 +1,5 @@
+-- The test script to run busted tests in a separate headless nvim process
+
 _G._run_tests = function(args)
   local success, error = pcall(function()
     local filters = args.filter or {}


### PR DESCRIPTION
Currently plenary adapters won't work out of box because plenary.nvim is
not added to vim &runtimepath or lua package.path (#4). Without any
config, test will fail with the error:

    .../neotest-plenary/run_tests.lua:26: module 'plenary.busted' not found:
    ^Ino field package.preload['plenary.busted']

Instead, we can get the path where plenary.nvim is installed and inject
the path when running a headless neovim instance for testing. With this,
neotest-plenary can run plenary.busted tests out-of-box even if users
do not configure `{ min_init = ... }`.

Fixes #4.
