### PR TITLE
fix: importing neotest-plenary causing lua print() broken

### DIFF
--- a/lua/neotest-plenary/init.lua
+++ b/lua/neotest-plenary/init.lua
@@ -3,12 +3,6 @@ local Path = require("plenary.path")
 local lib = require("neotest.lib")
 local base = require("neotest-plenary.base")
 
--- the local path to the plenary.nvim plugin installed
----@type string
-local plenary_dir = vim.fn.fnamemodify(
-  debug.getinfo(require("plenary.busted").run).source:match("@?(.*[/\\])"), ":p:h:h:h"
-)
-
 local config = {
   min_init = nil,
 }
@@ -112,6 +106,12 @@ function PlenaryNeotestAdapter.build_spec(args)
       end
     end
   end
+
+  -- the local path to the plenary.nvim plugin installed
+  ---@type string
+  local plenary_dir = vim.fn.fnamemodify(
+    debug.getinfo(require("plenary.path").__index).source:match("@?(.*[/\\])"), ":p:h:h:h"
+  )
 
   local cwd = assert(vim.loop.cwd())
   local command = vim.tbl_flatten({


### PR DESCRIPTION
Upon require("neotest-plenary"), lua global `print()` (and hence all
lua-based I/O) gets broken. This is because the module "plenary.busted"
overrides and shadows global `print()` as a side-effect.

This is a regression since #10.

Solution: The module "plenary.busted" should never be imported.
