### PR TITLE
Remove ansi sequence from luassert output

### DIFF
--- a/run_tests.lua
+++ b/run_tests.lua
@@ -25,6 +25,8 @@ _G._run_tests = function(args)
     end
 
     local busted = require("plenary.busted")
+    require("luassert.assert"):set_parameter("TableErrorHighlightColor", "none")
+
     -- May be optional
     pcall(vim.cmd, "packadd neotest")
     local base_format = busted.format_results


### PR DESCRIPTION
## Details

When running in a TTY luassert defaults to adding ansi colors when showning table differences for a failed test:
https://github.com/nvim-lua/plenary.nvim/blob/master/lua/luassert/formatters/init.lua#L255

When looking at these through the `neotest` panel everything looks great. However diagnostics do not appear to have any ansi parsing and instead print out the raw sequence.

The parameter that defines the color can be modified and effectively disabled by setting it to "none".

| Before | After |
| ------- | ----- |
| <img width="741" alt="current-ansii" src="https://github.com/user-attachments/assets/4c782ee6-a22f-4ebf-a0f7-3b30f0b78198"> |  <img width="713" alt="after-parameter" src="https://github.com/user-attachments/assets/4edc01bc-f12e-4b9f-b0d5-1f7a41c6ad2b"> |

This isn't a big deal and I can set it up per project. Also if I'm missing another way of handling this definitely LMK. As is this disables colors for both diagnostics as well as in the `neotest` panel.
